### PR TITLE
Add localized error handling

### DIFF
--- a/Api/Controllers/OpcController.cs
+++ b/Api/Controllers/OpcController.cs
@@ -1,5 +1,6 @@
 ﻿using ISKI.OpcUa.Client.Interfaces;
 using ISKI.OpcUa.Client.Models;
+using ISKI.OpcUa.Client.Errors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using static System.Runtime.InteropServices.JavaScript.JSType;
@@ -29,7 +30,7 @@ public class OpcController(
                 return Ok(new ConnectionResult<object>
                 {
                     ServerStatus = "AlreadyConnected",
-                    Message = "Zaten bağlı.",
+                    Message = ErrorMessages.GetMessage(ErrorCode.AlreadyConnected),
                 });
             }
 
@@ -50,7 +51,7 @@ public class OpcController(
             return StatusCode(500, new ConnectionResult<object>
             {
                 ServerStatus = "Exception",
-                Message = $"Bağlantı kurulamadı: {ex.Message}",
+                Message = $"{ErrorMessages.GetMessage(ErrorCode.ConnectionFailed)} {ex.Message}",
             });
         }
     }
@@ -127,7 +128,7 @@ public class OpcController(
             return StatusCode(500, new ConnectionResult<List<NodeBrowseResult>>
             {
                 ServerStatus = "Exception",
-                Message = $"Browse işlemi hatası: {ex.Message}",
+                Message = $"{ErrorMessages.GetMessage(ErrorCode.BrowseFailed)} {ex.Message}",
             });
         }
     }
@@ -156,7 +157,7 @@ public class OpcController(
             return StatusCode(500, new ConnectionResult<List<string>>
             {
                 ServerStatus = "Exception",
-                Message = $"Sunucu keşfi hatası: {ex.Message}",
+                Message = $"{ErrorMessages.GetMessage(ErrorCode.DiscoveryFailed)} {ex.Message}",
             });
         }
     }
@@ -184,7 +185,7 @@ public class OpcController(
             return StatusCode(500, new ConnectionResult<object>
             {
                 ServerStatus = "Exception",
-                Message = $"Bağlantı kesilemedi: {ex.Message}",
+                Message = $"{ErrorMessages.GetMessage(ErrorCode.DisconnectFailed)} {ex.Message}",
             });
         }
     }

--- a/ISKI.OpcUa.Client/Errors/ErrorCode.cs
+++ b/ISKI.OpcUa.Client/Errors/ErrorCode.cs
@@ -1,0 +1,16 @@
+namespace ISKI.OpcUa.Client.Errors;
+
+public enum ErrorCode
+{
+    None = 0,
+    AlreadyConnected = 100,
+    ConnectionFailed = 101,
+    SessionNotConnected = 102,
+    DisconnectFailed = 103,
+    ReadFailed = 104,
+    WriteFailed = 105,
+    BrowseFailed = 106,
+    DiscoveryFailed = 107,
+    NodeStatusInvalid = 108,
+    UnknownException = 500
+}

--- a/ISKI.OpcUa.Client/Errors/ErrorMessages.cs
+++ b/ISKI.OpcUa.Client/Errors/ErrorMessages.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+namespace ISKI.OpcUa.Client.Errors;
+
+public static class ErrorMessages
+{
+    public const string DefaultCulture = "tr";
+
+    // Turkish messages
+    public const string AlreadyConnectedTr = "Zaten bağlı.";
+    public const string ConnectionFailedTr = "Bağlantı kurulamadı.";
+    public const string SessionNotConnectedTr = "OPC UA oturumu bağlı değil.";
+    public const string DisconnectFailedTr = "Bağlantı kesilemedi.";
+    public const string ReadFailedTr = "Okuma işlemi başarısız.";
+    public const string WriteFailedTr = "Yazma işlemi başarısız.";
+    public const string BrowseFailedTr = "Browse işlemi hatalı.";
+    public const string DiscoveryFailedTr = "Sunucu keşfi hatası.";
+    public const string NodeStatusInvalidTr = "OPC veri durumu geçersiz.";
+    public const string UnknownExceptionTr = "Beklenmeyen hata oluştu.";
+
+    // English messages
+    public const string AlreadyConnectedEn = "Already connected.";
+    public const string ConnectionFailedEn = "Failed to connect.";
+    public const string SessionNotConnectedEn = "OPC UA session is not connected.";
+    public const string DisconnectFailedEn = "Failed to disconnect.";
+    public const string ReadFailedEn = "Read operation failed.";
+    public const string WriteFailedEn = "Write operation failed.";
+    public const string BrowseFailedEn = "Browse operation failed.";
+    public const string DiscoveryFailedEn = "Server discovery failed.";
+    public const string NodeStatusInvalidEn = "Invalid OPC data status.";
+    public const string UnknownExceptionEn = "Unexpected error occurred.";
+
+    private static readonly Dictionary<string, IReadOnlyDictionary<ErrorCode, string>> _localized
+        = new()
+    {
+        ["tr"] = new Dictionary<ErrorCode, string>
+        {
+            { ErrorCode.AlreadyConnected, AlreadyConnectedTr },
+            { ErrorCode.ConnectionFailed, ConnectionFailedTr },
+            { ErrorCode.SessionNotConnected, SessionNotConnectedTr },
+            { ErrorCode.DisconnectFailed, DisconnectFailedTr },
+            { ErrorCode.ReadFailed, ReadFailedTr },
+            { ErrorCode.WriteFailed, WriteFailedTr },
+            { ErrorCode.BrowseFailed, BrowseFailedTr },
+            { ErrorCode.DiscoveryFailed, DiscoveryFailedTr },
+            { ErrorCode.NodeStatusInvalid, NodeStatusInvalidTr },
+            { ErrorCode.UnknownException, UnknownExceptionTr }
+        },
+        ["en"] = new Dictionary<ErrorCode, string>
+        {
+            { ErrorCode.AlreadyConnected, AlreadyConnectedEn },
+            { ErrorCode.ConnectionFailed, ConnectionFailedEn },
+            { ErrorCode.SessionNotConnected, SessionNotConnectedEn },
+            { ErrorCode.DisconnectFailed, DisconnectFailedEn },
+            { ErrorCode.ReadFailed, ReadFailedEn },
+            { ErrorCode.WriteFailed, WriteFailedEn },
+            { ErrorCode.BrowseFailed, BrowseFailedEn },
+            { ErrorCode.DiscoveryFailed, DiscoveryFailedEn },
+            { ErrorCode.NodeStatusInvalid, NodeStatusInvalidEn },
+            { ErrorCode.UnknownException, UnknownExceptionEn }
+        }
+    };
+
+    public static string GetMessage(ErrorCode code, string culture = DefaultCulture)
+    {
+        if (_localized.TryGetValue(culture, out var dict) && dict.TryGetValue(code, out var message))
+            return message;
+
+        if (_localized[DefaultCulture].TryGetValue(code, out var defaultMsg))
+            return defaultMsg;
+
+        return _localized[DefaultCulture][ErrorCode.UnknownException];
+    }
+}

--- a/ISKI.OpcUa.Client/Services/ConnectionService.cs
+++ b/ISKI.OpcUa.Client/Services/ConnectionService.cs
@@ -3,6 +3,7 @@ using Opc.Ua.Client;
 using Opc.Ua.Configuration;
 using Microsoft.Extensions.Logging;
 using ISKI.OpcUa.Client.Exceptions;
+using ISKI.OpcUa.Client.Errors;
 using ISKI.OpcUa.Client.Interfaces;
 
 namespace ISKI.OpcUa.Client.Services;
@@ -75,7 +76,7 @@ public class ConnectionService : IConnectionService
         catch (Exception ex)
         {
             _logger.LogError(ex, "OPC UA bağlantı kurulamadı.");
-            throw new OpcServiceException("Bağlantı kurulamadı", ex);
+            throw new OpcServiceException(ErrorMessages.GetMessage(ErrorCode.ConnectionFailed), ex);
         }
     }
 

--- a/ISKI.OpcUa.Client/Services/NodeBrowseService.cs
+++ b/ISKI.OpcUa.Client/Services/NodeBrowseService.cs
@@ -3,6 +3,7 @@ using Opc.Ua.Client;
 using Microsoft.Extensions.Logging;
 using ISKI.OpcUa.Client.Interfaces;
 using ISKI.OpcUa.Client.Models;
+using ISKI.OpcUa.Client.Errors;
 
 namespace ISKI.OpcUa.Client.Services;
 
@@ -19,7 +20,7 @@ public class NodeBrowseService(ILogger<NodeBrowseService> logger, IConnectionSer
             return
         [
             new() {
-                DisplayName = "Oturum yok",
+                DisplayName = ErrorMessages.GetMessage(ErrorCode.SessionNotConnected),
                 NodeId = "N/A",
                 NodeClass = "Error"
             }
@@ -72,7 +73,7 @@ public class NodeBrowseService(ILogger<NodeBrowseService> logger, IConnectionSer
             results.Clear();
             results.Add(new NodeBrowseResult
             {
-                DisplayName = $"Hata: {ex.Message}",
+                DisplayName = $"{ErrorMessages.GetMessage(ErrorCode.BrowseFailed)} {ex.Message}",
                 NodeId = nodeId,
                 NodeClass = "Exception"
             });

--- a/ISKI.OpcUa.Client/Services/NodeReadWriteService.cs
+++ b/ISKI.OpcUa.Client/Services/NodeReadWriteService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ISKI.OpcUa.Client.Exceptions;
 using ISKI.OpcUa.Client.Interfaces;
 using ISKI.OpcUa.Client.Models;
+using ISKI.OpcUa.Client.Errors;
 
 namespace ISKI.OpcUa.Client.Services;
 
@@ -15,7 +16,7 @@ public class NodeReadWriteService(ILogger<NodeReadWriteService> logger, IConnect
 
         if (session == null || !session.Connected)
         {
-            var msg = "OPC UA oturumu bağlı değil.";
+            var msg = ErrorMessages.GetMessage(ErrorCode.SessionNotConnected);
             logger.LogWarning("ReadNode - {Message}", msg);
             return new ConnectionResult<NodeReadResult>
             {
@@ -61,7 +62,7 @@ public class NodeReadWriteService(ILogger<NodeReadWriteService> logger, IConnect
         }
         catch (Exception ex)
         {
-            var msg = $"ReadNode exception: {ex.Message}";
+            var msg = $"{ErrorMessages.GetMessage(ErrorCode.ReadFailed)} {ex.Message}";
             logger.LogError(ex, "ReadNode exception: {Message}", ex.Message);
             return new ConnectionResult<NodeReadResult>
             {
@@ -83,7 +84,7 @@ public class NodeReadWriteService(ILogger<NodeReadWriteService> logger, IConnect
 
         if (session == null)
         {
-            var msg = "OPC UA oturumu bağlı değil.";
+            var msg = ErrorMessages.GetMessage(ErrorCode.SessionNotConnected);
             logger.LogWarning("WriteNode - {Message}", msg);
             return new ConnectionResult<object>
             {
@@ -109,7 +110,7 @@ public class NodeReadWriteService(ILogger<NodeReadWriteService> logger, IConnect
                 ServerStatus = status.ToString(),
                 Message = StatusCode.IsGood(status)
                     ? "Yazma işlemi başarılı."
-                    : $"Yazma başarısız. OPC Status: {status}",
+                    : $"{ErrorMessages.GetMessage(ErrorCode.WriteFailed)} OPC Status: {status}",
             };
 
             if (response.Success)
@@ -121,7 +122,7 @@ public class NodeReadWriteService(ILogger<NodeReadWriteService> logger, IConnect
         }
         catch (Exception ex)
         {
-            var msg = $"WriteNode exception: {ex.Message}";
+            var msg = $"{ErrorMessages.GetMessage(ErrorCode.WriteFailed)} {ex.Message}";
             logger.LogError(ex, "WriteNode exception: {Message}", ex.Message);
             return new ConnectionResult<object>
             {


### PR DESCRIPTION
## Summary
- add localized error messages and error codes
- use error codes in OPC UA services
- update API controller to utilize localization

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789a20f1188324b81508b87336c7b1