### PR TITLE
Add configurable network prefix for discovery

### DIFF
--- a/Api/Controllers/OpcController.cs
+++ b/Api/Controllers/OpcController.cs
@@ -135,11 +135,11 @@ public class OpcController(
 
 
     [HttpGet("discover")]
-    public async Task<ActionResult<ConnectionResult<List<string>>>> Discover()
+    public async Task<ActionResult<ConnectionResult<List<string>>>> Discover([FromQuery] string networkPrefix = "192.168.1", [FromQuery] int port = 4840)
     {
         try
         {
-            var servers = await discoveryService.FindServersOnLocalNetworkAsync();
+            var servers = await discoveryService.FindServersOnLocalNetworkAsync(networkPrefix, port);
 
             logger.LogInformation("Discover tamamlandı. Sunucu sayısı: {count}", servers.Count);
 

--- a/ISKI.OpcUa.Client/Interfaces/IDiscoveryService.cs
+++ b/ISKI.OpcUa.Client/Interfaces/IDiscoveryService.cs
@@ -2,5 +2,5 @@
 
 public interface IDiscoveryService
 {
-    Task<List<string>> FindServersOnLocalNetworkAsync();
+    Task<List<string>> FindServersOnLocalNetworkAsync(string networkPrefix = "192.168.1", int port = 4840);
 }

--- a/ISKI.OpcUa.Client/Interfaces/IOpcUaService.cs
+++ b/ISKI.OpcUa.Client/Interfaces/IOpcUaService.cs
@@ -9,5 +9,5 @@ public interface IOpcUaService
     Task<ConnectionResult<NodeReadResult>> ReadNodeAsync(string nodeId);
     Task WriteNodeAsync(string nodeId, object value, CancellationToken cancellationToken);
     List<NodeBrowseResult> Browse(string nodeId);
-    Task<List<string>> FindServersOnLocalNetworkAsync();
+    Task<List<string>> FindServersOnLocalNetworkAsync(string networkPrefix = "192.168.1", int port = 4840);
 }

--- a/ISKI.OpcUa.Client/Services/DiscoveryService.cs
+++ b/ISKI.OpcUa.Client/Services/DiscoveryService.cs
@@ -7,17 +7,16 @@ namespace ISKI.OpcUa.Client.Services;
 
 public class DiscoveryService(ILogger<DiscoveryService> logger) : IDiscoveryService
 {
-    public async Task<List<string>> FindServersOnLocalNetworkAsync()
+    public async Task<List<string>> FindServersOnLocalNetworkAsync(string networkPrefix = "192.168.1", int port = 4840)
     {
         var foundServers = new List<string>();
-        var port = 4840;
         var tasks = new List<Task>();
 
-        logger.LogInformation("Yerel ağda OPC sunucuları aranıyor...");
+        logger.LogInformation("Yerel ağ {networkPrefix}.x üzerinde OPC sunucuları aranıyor (port {port})...", networkPrefix, port);
 
         for (int i = 1; i <= 254; i++)
         {
-            string ip = $"192.168.1.{i}";
+            string ip = $"{networkPrefix}.{i}";
             string endpoint = $"opc.tcp://{ip}:{port}";
 
             tasks.Add(Task.Run(async () =>

--- a/ISKI.OpcUa.Client/Services/OpcUaService.cs
+++ b/ISKI.OpcUa.Client/Services/OpcUaService.cs
@@ -14,5 +14,5 @@ public class OpcUaService(
     public Task<ConnectionResult<NodeReadResult>> ReadNodeAsync(string nodeId) => readWrite.ReadNodeAsync(nodeId);
     public Task WriteNodeAsync(string nodeId, object value, CancellationToken ct) => readWrite.WriteNodeAsync(nodeId, value, ct);
     public List<NodeBrowseResult> Browse(string nodeId) => browser.Browse(nodeId);
-    public Task<List<string>> FindServersOnLocalNetworkAsync() => discovery.FindServersOnLocalNetworkAsync();
+    public Task<List<string>> FindServersOnLocalNetworkAsync(string networkPrefix = "192.168.1", int port = 4840) => discovery.FindServersOnLocalNetworkAsync(networkPrefix, port);
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dotnet add package ISKI.OpcUa.Client
 - ✅ OPC UA Session management with certificate support  
 - ✅ Read & Write to node values  
 - ✅ Browse server nodes (with metadata)  
-- ✅ Discover servers on local network  
+- ✅ Discover servers on local network with configurable range
 - ✅ Structured, consistent response models with `ConnectionResult<T>`  
 - ✅ Full integration with ASP.NET Core Dependency Injection  
 - ✅ Built-in logging support with `ILogger`
@@ -71,6 +71,18 @@ foreach (var node in nodes)
     Console.WriteLine($"{node.DisplayName} [{node.NodeClass}] - {node.NodeId}");
 }
 ```
+
+### Discover servers:
+
+```csharp
+List<string> servers = await opcUaService.FindServersOnLocalNetworkAsync("192.168.100", 4840);
+foreach (var server in servers)
+{
+    Console.WriteLine(server);
+}
+```
+
+Network prefix and port are configurable to match your local setup.
 
 ---
 


### PR DESCRIPTION
## Summary
- enable passing network prefix and port when discovering servers
- update API controller to accept discovery query parameters
- document usage of configurable discovery in README

## Testing
- `dotnet build ISKI.OpcUa.SDK.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c5c18828832480cabd31caf4b6d8