### PR TITLE
Add OPC UA node tree browsing

### DIFF
--- a/Api/Controllers/OpcController.cs
+++ b/Api/Controllers/OpcController.cs
@@ -133,6 +133,34 @@ public class OpcController(
         }
     }
 
+    [HttpGet("tree")]
+    public ActionResult<ConnectionResult<NodeTreeResult>> BrowseTree([FromQuery] string nodeId = "i=85")
+    {
+        try
+        {
+            var tree = browseService.BrowseTree(nodeId);
+
+            logger.LogInformation("BrowseTree: Node {nodeId}", nodeId);
+
+            return Ok(new ConnectionResult<NodeTreeResult>
+            {
+                ServerStatus = "Good",
+                Message = "BrowseTree işlemi başarılı.",
+                Data = tree
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "BrowseTree hatası.");
+
+            return StatusCode(500, new ConnectionResult<NodeTreeResult>
+            {
+                ServerStatus = "Exception",
+                Message = $"{ErrorMessages.GetMessage(ErrorCode.BrowseFailed)} {ex.Message}",
+            });
+        }
+    }
+
 
     [HttpGet("discover")]
     public async Task<ActionResult<ConnectionResult<List<string>>>> Discover()

--- a/ISKI.OpcUa.Client/Interfaces/INodeBrowseService.cs
+++ b/ISKI.OpcUa.Client/Interfaces/INodeBrowseService.cs
@@ -5,4 +5,5 @@ namespace ISKI.OpcUa.Client.Interfaces;
 public interface INodeBrowseService
 {
     List<NodeBrowseResult> Browse(string nodeId);
+    NodeTreeResult BrowseTree(string nodeId);
 }

--- a/ISKI.OpcUa.Client/Interfaces/IOpcUaService.cs
+++ b/ISKI.OpcUa.Client/Interfaces/IOpcUaService.cs
@@ -9,5 +9,6 @@ public interface IOpcUaService
     Task<ConnectionResult<NodeReadResult>> ReadNodeAsync(string nodeId);
     Task WriteNodeAsync(string nodeId, object value, CancellationToken cancellationToken);
     List<NodeBrowseResult> Browse(string nodeId);
+    NodeTreeResult BrowseTree(string nodeId);
     Task<List<string>> FindServersOnLocalNetworkAsync();
 }

--- a/ISKI.OpcUa.Client/Models/NodeTreeResult.cs
+++ b/ISKI.OpcUa.Client/Models/NodeTreeResult.cs
@@ -1,0 +1,9 @@
+namespace ISKI.OpcUa.Client.Models;
+
+public class NodeTreeResult
+{
+    public string DisplayName { get; set; } = string.Empty;
+    public string NodeId { get; set; } = string.Empty;
+    public string NodeClass { get; set; } = string.Empty;
+    public List<NodeTreeResult> Children { get; set; } = new();
+}

--- a/ISKI.OpcUa.Client/Services/NodeBrowseService.cs
+++ b/ISKI.OpcUa.Client/Services/NodeBrowseService.cs
@@ -81,4 +81,71 @@ public class NodeBrowseService(ILogger<NodeBrowseService> logger, IConnectionSer
 
         return results;
     }
+
+    public NodeTreeResult BrowseTree(string nodeId)
+    {
+        var session = connection.Session;
+
+        if (session == null)
+        {
+            logger.LogWarning("BrowseTree çağrısı yapıldı ama oturum yok.");
+            return new NodeTreeResult
+            {
+                DisplayName = ErrorMessages.GetMessage(ErrorCode.SessionNotConnected),
+                NodeId = "N/A",
+                NodeClass = "Error",
+                Children = []
+            };
+        }
+
+        try
+        {
+            var tree = BrowseRecursive(session, new NodeId(nodeId));
+            logger.LogInformation("BrowseTree işlemi tamamlandı.");
+            return tree;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "BrowseTree sırasında hata oluştu: {nodeId}", nodeId);
+            return new NodeTreeResult
+            {
+                DisplayName = $"{ErrorMessages.GetMessage(ErrorCode.BrowseFailed)} {ex.Message}",
+                NodeId = nodeId,
+                NodeClass = "Exception",
+                Children = []
+            };
+        }
+    }
+
+    private NodeTreeResult BrowseRecursive(Session session, NodeId nodeId)
+    {
+        var node = session.ReadNode(nodeId);
+        var current = new NodeTreeResult
+        {
+            DisplayName = node.DisplayName.Text,
+            NodeId = nodeId.ToString(),
+            NodeClass = node.NodeClass.ToString(),
+            Children = []
+        };
+
+        var browseDesc = new BrowseDescription
+        {
+            NodeId = nodeId,
+            BrowseDirection = BrowseDirection.Forward,
+            ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
+            IncludeSubtypes = true,
+            NodeClassMask = (uint)(NodeClass.Object | NodeClass.Variable),
+            ResultMask = (uint)BrowseResultMask.All
+        };
+
+        session.Browse(null, null, 0, [browseDesc], out var browseResults, out _);
+
+        foreach (var reference in browseResults[0].References)
+        {
+            var childId = ExpandedNodeId.ToNodeId(reference.NodeId, session.NamespaceUris);
+            current.Children.Add(BrowseRecursive(session, childId));
+        }
+
+        return current;
+    }
 }

--- a/ISKI.OpcUa.Client/Services/OpcUaService.cs
+++ b/ISKI.OpcUa.Client/Services/OpcUaService.cs
@@ -14,5 +14,6 @@ public class OpcUaService(
     public Task<ConnectionResult<NodeReadResult>> ReadNodeAsync(string nodeId) => readWrite.ReadNodeAsync(nodeId);
     public Task WriteNodeAsync(string nodeId, object value, CancellationToken ct) => readWrite.WriteNodeAsync(nodeId, value, ct);
     public List<NodeBrowseResult> Browse(string nodeId) => browser.Browse(nodeId);
+    public NodeTreeResult BrowseTree(string nodeId) => browser.BrowseTree(nodeId);
     public Task<List<string>> FindServersOnLocalNetworkAsync() => discovery.FindServersOnLocalNetworkAsync();
 }


### PR DESCRIPTION
## Summary
- add a `NodeTreeResult` model
- extend browsing services with `BrowseTree`
- expose new API endpoint `/api/opc/tree`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c5e13d3c8324bcb87f30f25b6ddc