### PR TITLE
Update README for correct .NET support

### DIFF
--- a/ISKI.OpcUa.Client/README.md
+++ b/ISKI.OpcUa.Client/README.md
@@ -8,7 +8,7 @@
 dotnet add package ISKI.OpcUa.Client
 ```
 
-> Supports **.NET 6**, **.NET 7**, and **.NET 8**.
+> Supports **.NET 8**.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix README framework line to mention only .NET 8

## Testing
- `dotnet build ISKI.OpcUa.SDK.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878cac124d08324a06e5d7d69caa895